### PR TITLE
Fix wallet purchase setup

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -11,6 +11,7 @@ export function Providers({ children }: { children: ReactNode }) {
       config={{
         loginMethods: ['wallet'],
         appearance: {
+          showWalletLoginFirst: true,
           theme: 'light',
           accentColor: '#676FFF',
           walletChainType: 'ethereum-only',


### PR DESCRIPTION
## Summary
- keep a single Unlock wallet service instance
- show wallet login first in the Privy appearance config
- log detailed purchase failure reason

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: invalid Privy app ID)*

------
https://chatgpt.com/codex/tasks/task_e_688b6516593c8321abf6242a340ccbb0