### PR TITLE
Protect lambda source during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "compile:lambda": "esbuild lambda/generateSignedUrl.ts --bundle --platform=node --target=node18 --format=cjs --tsconfig=tsconfig.lambda.json --outfile=lambda-build/index.js",
     "package:lambda": "cd lambda-build && zip ../generateSignedUrl.zip index.js",
     "build:lambda": "npm run compile:lambda && npm run package:lambda",
-    "build": "npm run build:lambda && next build && mv out out-temp && mkdir -p out/community && mv out-temp/* out/community/ && rm -rf out-temp",
+    "build": "npm run build:lambda && next build && mv out out-temp && mkdir -p out/community && mv out-temp/* out/community/ && rm -rf out-temp && true",
     "start": "next start",
     "lint": "next lint",
     "serve": "serve out -r '{\"source\": \"/community\",\"destination\": \"/community.html\"}' -r '{\"source\": \"/community/(.*)\",\"destination\": \"/$1\"}'"


### PR DESCRIPTION
## Summary
- prevent unintended deletion of the `lambda` directory when running `npm run build lambda`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688df983cd708321b9c991284b7fc521