### PR TITLE
Declare Unlock paywall module

### DIFF
--- a/types/unlock-protocol-paywall.d.ts
+++ b/types/unlock-protocol-paywall.d.ts
@@ -1,0 +1,7 @@
+declare module '@unlock-protocol/paywall' {
+  export class Paywall {
+    constructor(config: any);
+    connect(provider: any): Promise<void>;
+    loadCheckoutModal(config: any): Promise<void>;
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal TypeScript declarations for `@unlock-protocol/paywall` so Next.js build can locate its types

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: ESLint requires setup and prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688ecc51cb108321aae4682ea9bb07be