### PR TITLE
Add membership-gated content API route

### DIFF
--- a/app/api/content/[file]/route.ts
+++ b/app/api/content/[file]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Contract, JsonRpcProvider } from 'ethers';
+import { getSignedUrl } from '@/lambda/cloudFrontSigner';
+
+const LOCK_ADDRESS = process.env.LOCK_ADDRESS as string;
+const NETWORK_ID = Number(process.env.NETWORK_ID);
+const BASE_RPC_URL = process.env.BASE_RPC_URL as string;
+const CLOUDFRONT_DOMAIN = process.env.CLOUDFRONT_DOMAIN as string;
+const KEY_PAIR_ID = process.env.KEY_PAIR_ID as string;
+const PRIVATE_KEY = process.env.PRIVATE_KEY as string;
+
+const ABI = [
+  'function totalKeys(address) view returns (uint256)',
+  'function getHasValidKey(address) view returns (bool)',
+];
+
+export async function GET(request: NextRequest, { params }: { params: { file: string } }) {
+  const address = request.nextUrl.searchParams.get('address');
+  const file = params.file;
+
+  if (!address || !file) {
+    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });
+  }
+
+  try {
+    const provider = new JsonRpcProvider(BASE_RPC_URL, NETWORK_ID);
+    const lock = new Contract(LOCK_ADDRESS, ABI, provider);
+
+    const total = await lock.totalKeys(address);
+    if (total.toString() === '0') {
+      return NextResponse.json({ error: 'No membership' }, { status: 403 });
+    }
+
+    const valid = await lock.getHasValidKey(address);
+    if (!valid) {
+      return NextResponse.json({ error: 'Membership expired' }, { status: 403 });
+    }
+
+    const expires = Math.floor(Date.now() / 1000) + 60 * 5; // 5 minutes
+    const url = getSignedUrl({
+      url: `https://${CLOUDFRONT_DOMAIN}/${file}`,
+      keyPairId: KEY_PAIR_ID,
+      privateKey: PRIVATE_KEY,
+      expires,
+    });
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error('Failed to generate URL', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,6 @@ import { base } from 'viem/chains'; // Base chain definition
 import { Paywall } from '@unlock-protocol/paywall';
 import { networks } from '@unlock-protocol/networks';
 import {
-  SIGNER_URL,
   LOCK_ADDRESS,
   BASE_NETWORK_ID,
   BASE_RPC_URL,
@@ -148,12 +147,8 @@ export default function Home() {
       console.error('No wallet connected.');
       return;
     }
-    if (!SIGNER_URL) {
-      console.error('Signer URL not configured');
-      return;
-    }
     try {
-      const res = await fetch(`${SIGNER_URL}?address=${w.address}&file=${file}`);
+      const res = await fetch(`/api/content/${file}?address=${w.address}`);
       if (!res.ok) {
         throw new Error('Failed to fetch signed URL');
       }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,3 @@
-export const SIGNER_URL = process.env.NEXT_PUBLIC_SIGNER_URL as string;
 export const UNLOCK_ADDRESS = process.env.NEXT_PUBLIC_UNLOCK_ADDRESS as string;
 export const LOCK_ADDRESS = process.env.NEXT_PUBLIC_LOCK_ADDRESS as string;
 export const BASE_NETWORK_ID = Number(process.env.NEXT_PUBLIC_BASE_NETWORK_ID);


### PR DESCRIPTION
## Summary
- expose CloudFront signed URL via new `/api/content/[file]` route with membership check
- remove external SIGNER_URL usage by fetching from internal API in page component
- drop unused SIGNER_URL config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_688f348e27408321b7275e10b66975dd