### PR TITLE
Fix Next.js route handler type

### DIFF
--- a/app/api/content/[file]/route.ts
+++ b/app/api/content/[file]/route.ts
@@ -14,9 +14,12 @@ const ABI = [
   'function getHasValidKey(address) view returns (bool)',
 ];
 
-export async function GET(request: NextRequest, { params }: { params: { file: string } }) {
+export async function GET(
+  request: NextRequest,
+  context: { params: { file: string } }
+) {
   const address = request.nextUrl.searchParams.get('address');
-  const file = params.file;
+  const file = context.params.file;
 
   if (!address || !file) {
     return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });


### PR DESCRIPTION
## Summary
- fix route handler signature to use a context object for params

## Testing
- `npm run lint`
- `npm run build` *(fails: stuck at "Creating an optimized production build ...")*

------
https://chatgpt.com/codex/tasks/task_e_688f4b53c3788321a73d1ad17099c58b