### PR TITLE
Fix Next.js route handler type

### DIFF
--- a/app/api/content/[file]/route.ts
+++ b/app/api/content/[file]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Contract, JsonRpcProvider } from 'ethers';
 import { getSignedUrl } from '@/lambda/cloudFrontSigner';
 
@@ -14,8 +14,11 @@ const ABI = [
   'function getHasValidKey(address) view returns (bool)',
 ];
 
-export async function GET(request: NextRequest, { params }: { params: { file: string } }) {
-  const address = request.nextUrl.searchParams.get('address');
+export async function GET(
+  request: Request,
+  { params }: { params: { file: string } }
+) {
+  const address = new URL(request.url).searchParams.get('address');
   const file = params.file;
 
   if (!address || !file) {


### PR DESCRIPTION
## Summary
- use standard Request and destructured params in content route handler

## Testing
- `npm run lint` (prompts for ESLint configuration)
- `npm run build` (stuck at "Creating an optimized production build ...")

------
https://chatgpt.com/codex/tasks/task_e_688f4b53c3788321a73d1ad17099c58b