### PR TITLE
Add Amplify build specification

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,16 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm ci
+    build:
+      commands:
+        - npm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*


### PR DESCRIPTION
## Summary
- add AWS Amplify buildspec for Next.js app deployment

## Testing
- `npm run build` *(fails: Cannot initialize the Privy provider with an invalid Privy app ID)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a38a41a948321b2f3b97eb7bc0d7e