### PR TITLE
chore: update Node version and tsconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ethers@6.15.0
 
 Development Dependencies:
 @tailwindcss/postcss@4
-@types/node@20
+@types/node@24
 @types/react@19
 @types/react-dom@19
 esbuild@0.19.12
@@ -153,7 +153,7 @@ NEXT_PUBLIC_USDC_ADDRESS=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
 npm run build:lambda
 ```
 
-   - Upload `generateSignedUrl.zip` from the project root when creating the Lambda function (runtime Node.js 22.x) and use the IAM role from the previous step. Set the following environment variables (adjust for your resources):
+   - Upload `generateSignedUrl.zip` from the project root when creating the Lambda function (runtime Node.js 24.x) and use the IAM role from the previous step. Set the following environment variables (adjust for your resources):
 
 ```
 BASE_RPC_URL=https://mainnet.base.org

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "pgpforcrypto-community",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "next dev",
-    "compile:lambda": "esbuild lambda/generateSignedUrl.ts --bundle --platform=node --target=node18 --format=cjs --tsconfig=tsconfig.lambda.json --outfile=lambda-build/index.js",
+    "compile:lambda": "esbuild lambda/generateSignedUrl.ts --bundle --platform=node --target=node24 --format=cjs --tsconfig=tsconfig.lambda.json --outfile=lambda-build/index.js",
     "package:lambda": "cd lambda-build && zip ../generateSignedUrl.zip index.js",
     "build:lambda": "npm run compile:lambda && npm run package:lambda",
     "build": "npm run build:lambda && next build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "out/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- target Node.js 24 in lambda build and declare minimum runtime
- include generated type declarations in `tsconfig.json`
- document Node.js 24 usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a5d4d2ffc8321ab43ebdb71d688e5