### PR TITLE
chore: use Node 20 for Amplify runtime

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,7 +1,7 @@
 version: 1
 frontend:
   runtime:
-    nodejs: 24
+    nodejs: 20
   phases:
     preBuild:
       commands:


### PR DESCRIPTION
## Summary
- use Node.js 20 in Amplify config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `nvm install 20`
- `nvm use 20`


------
https://chatgpt.com/codex/tasks/task_e_689b4bab6bc4832180c5ee4a26f359c5