### PR TITLE
Remove out-types include from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts",
-    "out/types/**/*.ts"
+    ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- remove generated out/types directory from TypeScript include list

## Testing
- `npm run build` *(fails: Cannot initialize the Privy provider with an invalid Privy app ID)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b6689ec408321a13f69a1f2072d62