### PR TITLE
fix: align Next.js dist directory with Amplify config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   trailingSlash: true, // Ensures compatibility with S3/CloudFront
   basePath: '/community', // Sets the subdirectory path
   assetPrefix: '/community/',
-  distDir: 'out',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- remove custom `distDir` from Next.js config so Amplify packages the default `.next` output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt for ESLint config)*
- `npm run build` *(fails: Cannot initialize the Privy provider with an invalid Privy app ID)*

------
https://chatgpt.com/codex/tasks/task_e_689b73ef79988321b4d0ba3de4a5cb32