### PR TITLE
Refactor content route handler signature

### DIFF
--- a/app/api/content/[file]/route.ts
+++ b/app/api/content/[file]/route.ts
@@ -34,10 +34,10 @@ export const revalidate = 0;
 
 export async function GET(
   request: NextRequest,
-  context: { params: Promise<{ file: string }> }
+  { params }: { params: { file: string } }
 ) {
   const address = request.nextUrl.searchParams.get('address');
-  const { file } = await context.params;
+  const { file } = params;
 
   if (!address || !file) {
     return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });


### PR DESCRIPTION
## Summary
- simplify API route handler signature to destructure params without a promise
- remove unnecessary await on params in content API route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689b7771052c83218325895b4a0e4df5