### PR TITLE
Use RouteContext for dynamic content route

### DIFF
--- a/app/api/content/[file]/route.ts
+++ b/app/api/content/[file]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import type { RouteContext } from 'next';
 import { Contract, JsonRpcProvider } from 'ethers';
 import { getSignedUrl } from '@/lambda/cloudFrontSigner';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
@@ -34,10 +35,10 @@ export const revalidate = 0;
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { file: string } }
+  context: RouteContext<{ file: string }>
 ) {
   const address = request.nextUrl.searchParams.get('address');
-  const { file } = params;
+  const { file } = context.params;
 
   if (!address || !file) {
     return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });


### PR DESCRIPTION
## Summary
- import RouteContext from next and apply to the dynamic content route handler
- destructure the file param from the provided RouteContext

## Testing
- `npm run lint` *(fails: Next.js requested plugin install)*
- `npx next build` *(fails: stalled at "Creating an optimized production build ...")*


------
https://chatgpt.com/codex/tasks/task_e_689b7f1be00883218e32282f7d80bfb2