### PR TITLE
refactor: type route context

### DIFF
--- a/app/api/content/[file]/route.ts
+++ b/app/api/content/[file]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import type { RouteContext } from 'next';
 import { Contract, JsonRpcProvider } from 'ethers';
 import { getSignedUrl } from '@/lambda/cloudFrontSigner';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
@@ -34,10 +35,10 @@ export const revalidate = 0;
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { file: string } }
+  context: RouteContext<{ file: string }>
 ) {
   const address = request.nextUrl.searchParams.get('address');
-  const { file } = params;
+  const { file } = context.params;
 
   if (!address || !file) {
     return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });

--- a/types/route-context.d.ts
+++ b/types/route-context.d.ts
@@ -1,0 +1,7 @@
+import 'next';
+
+declare module 'next' {
+  export interface RouteContext<P = Record<string, string>> {
+    params: P;
+  }
+}


### PR DESCRIPTION
## Summary
- use RouteContext in content file route handler
- declare RouteContext type to enable typed params

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689bb1f9fd3c8321a7b2badd051360e6