### PR TITLE
Disable unauthenticated pending-signup wallet linking and remove auto-linking

### DIFF
--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -124,16 +124,6 @@ function SignupFlow({ callbackUrl }: { callbackUrl: string }) {
     try {
       if (!/.+@.+\..+/.test(email)) throw new Error("Enter a valid email address");
       if (!walletAddress) throw new Error("Wallet address missing. Please reconnect.");
-      const pendingRes = await fetch("/api/signup/pending", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, wallet: walletAddress }),
-      });
-      if (!pendingRes.ok) {
-        let detail: any = undefined;
-        try { detail = await pendingRes.json(); } catch {}
-        throw new Error(detail?.error || "Failed to save signup state");
-      }
       try {
         localStorage.removeItem("pendingProfile");
       } catch {}
@@ -203,7 +193,7 @@ function SignupFlow({ callbackUrl }: { callbackUrl: string }) {
             <Mail className="h-5 w-5" /> Enter Your Email
           </div>
           <p className="text-sm text-muted-foreground">
-            We&apos;ll send you a verification link to complete your sign-up.
+            We&apos;ll send you a verification link to sign in. After that, link your wallet from your account settings.
           </p>
           <div className="rounded-md border border-emerald-300/60 bg-emerald-50 p-3 text-sm text-emerald-900 dark:text-emerald-200 dark:bg-emerald-500/10">
             <div className="flex items-start gap-2">

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -20,58 +20,6 @@ import {
 import { getMembershipSummary } from "@/lib/membership-server";
 import { documentClient, TABLE_NAME } from "@/lib/dynamodb";
 
-const PENDING_SIGNUP_PREFIX = "PENDING_SIGNUP#";
-
-async function consumePendingSignup(email: string | null | undefined, userId: string, adapter: any) {
-  if (!email || !userId) return null;
-  const normalizedEmail = email.trim().toLowerCase();
-  const key = `${PENDING_SIGNUP_PREFIX}${normalizedEmail}`;
-  const pending = await documentClient.get({
-    TableName: TABLE_NAME,
-    Key: { pk: key, sk: key },
-  });
-  const item = pending.Item as any;
-  const wallet = item?.wallet ? String(item.wallet).toLowerCase() : null;
-  if (!wallet) {
-    if (item) {
-      await documentClient.delete({ TableName: TABLE_NAME, Key: { pk: key, sk: key } });
-    }
-    return null;
-  }
-
-  try {
-    const existing = await adapter.getUserByAccount({
-      provider: "ethereum",
-      providerAccountId: wallet,
-    });
-    if (existing && existing.id && existing.id !== userId) {
-      await documentClient.delete({ TableName: TABLE_NAME, Key: { pk: key, sk: key } });
-      return null;
-    }
-    if (!existing) {
-      await adapter.linkAccount({
-        userId,
-        type: "credentials",
-        provider: "ethereum",
-        providerAccountId: wallet,
-      });
-    }
-
-    const user = await adapter.getUser(userId);
-    const current = Array.isArray((user as any)?.wallets)
-      ? ((user as any).wallets as string[])
-      : [];
-    if (!current.includes(wallet)) {
-      await adapter.updateUser({ id: userId, wallets: [...current, wallet] });
-    }
-  } catch (err) {
-    console.error("Failed to consume pending signup", err);
-  }
-
-  await documentClient.delete({ TableName: TABLE_NAME, Key: { pk: key, sk: key } });
-  return wallet;
-}
-
 // Ensure NextAuth sees a base URL for callbacks (used by Email provider)
 if (!process.env.NEXTAUTH_URL && NEXTAUTH_URL) {
   process.env.NEXTAUTH_URL = NEXTAUTH_URL;
@@ -245,11 +193,7 @@ export const authOptions = {
           const adapter: any = DynamoDBAdapter(documentClient as any, {
             tableName: TABLE_NAME,
           });
-          let userRecord = await adapter.getUser(token.sub);
-          if (userRecord?.email) {
-            await consumePendingSignup((userRecord as any).email as string, token.sub, adapter);
-            userRecord = await adapter.getUser(token.sub);
-          }
+          const userRecord = await adapter.getUser(token.sub);
           const wallets = Array.isArray((userRecord as any)?.wallets)
             ? ((userRecord as any).wallets as string[])
             : [];

--- a/app/api/signup/pending/route.ts
+++ b/app/api/signup/pending/route.ts
@@ -1,40 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
-import { documentClient, TABLE_NAME } from "@/lib/dynamodb";
+import { NextResponse } from "next/server";
 
-const PK_PREFIX = "PENDING_SIGNUP#";
-
-export async function POST(req: NextRequest) {
-  try {
-    const { email, wallet } = await req.json();
-    if (!email || !wallet) {
-      return NextResponse.json({ error: "email and wallet are required" }, { status: 400 });
-    }
-    const emailLower = String(email).trim().toLowerCase();
-    const walletLower = String(wallet).trim().toLowerCase();
-    if (!/.+@.+\..+/.test(emailLower)) {
-      return NextResponse.json({ error: "Invalid email" }, { status: 400 });
-    }
-    if (!/^0x[a-f0-9]{40}$/.test(walletLower)) {
-      return NextResponse.json({ error: "Invalid wallet address" }, { status: 400 });
-    }
-
-    const key = `${PK_PREFIX}${emailLower}`;
-    await documentClient.put({
-      TableName: TABLE_NAME,
-      Item: {
-        pk: key,
-        sk: key,
-        type: "PENDING_SIGNUP",
-        email: emailLower,
-        wallet: walletLower,
-        createdAt: new Date().toISOString(),
-      },
-    });
-
-    return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    const msg = typeof e?.message === "string" ? e.message : "Failed to store pending signup";
-    console.error("/api/signup/pending error:", msg);
-    return NextResponse.json({ error: "Internal error" }, { status: 500 });
-  }
+export async function POST() {
+  return NextResponse.json(
+    {
+      error:
+        "Pending signup wallet linking is no longer supported. Sign in with email, then link your wallet from your account settings.",
+    },
+    { status: 410 }
+  );
 }


### PR DESCRIPTION
### Motivation
- Close a high-risk account-linking injection where unauthenticated POSTs to `/api/signup/pending` could store arbitrary `email -> wallet` mappings. 
- Prevent automatic wallet linking during session creation that consumed these pending entries and allowed attacker-controlled wallets to be attached to victim accounts without ownership proof.

### Description
- Removed the `consumePendingSignup` helper and the `PENDING_SIGNUP#` auto-consumption path from `app/api/auth/[...nextauth]/route.ts` so NextAuth session creation no longer links wallets by email lookup. 
- Replaced the `/api/signup/pending` implementation in `app/api/signup/pending/route.ts` with a `410 Gone` response and guidance to use authenticated wallet linking after email sign-in. 
- Updated the sign-in UX in `app/(auth)/signin/page.tsx` to stop calling `/api/signup/pending` and to clarify that wallet linking must be done from account settings after signing in.

### Testing
- Ran `npm run lint` which completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceba2dd50883219088c53a961249be)